### PR TITLE
Fix unpredictable md5 sum

### DIFF
--- a/src/decimals/crypto.clj
+++ b/src/decimals/crypto.clj
@@ -16,7 +16,7 @@
 (defn map->md5
   [data]
   (->> data
-       json/write-str
+       sorted-map
        .getBytes
        (.digest (MessageDigest/getInstance "MD5"))
        (BigInteger. 1)

--- a/src/decimals/crypto.clj
+++ b/src/decimals/crypto.clj
@@ -13,14 +13,18 @@
        (BigInteger. 1)
        (format "%032x")))
 
-(defn sort-map [data]
-  (into (sorted-map) (sort-by first (seq data))))
+(defn map->tuple [data]
+  (str
+   (:id data)
+   (:from data)
+   (:to data)
+   (:amount data)
+   (:currency data)))
 
 (defn map->md5
   [data]
   (->> data
-       sort-map
-       prn-str
+       map->tuple
        .getBytes
        (.digest (MessageDigest/getInstance "MD5"))
        (BigInteger. 1)

--- a/src/decimals/crypto.clj
+++ b/src/decimals/crypto.clj
@@ -13,10 +13,14 @@
        (BigInteger. 1)
        (format "%032x")))
 
+(defn sort-map [data]
+  (into (sorted-map) (sort-by first (seq data))))
+
 (defn map->md5
   [data]
   (->> data
-       sorted-map
+       sort-map
+       prn-str
        .getBytes
        (.digest (MessageDigest/getInstance "MD5"))
        (BigInteger. 1)

--- a/test/decimals/crypto_test.clj
+++ b/test/decimals/crypto_test.clj
@@ -1,0 +1,18 @@
+(ns decimals.crypto-test
+  (:require [clojure.test :refer :all]
+            [decimals.crypto :as c]))
+
+(deftest map-hash-test
+  (let [m {:foo 300 :toto 600}
+        mm {:foo m}
+        t (assoc (assoc {} :toto 600) :foo 300)
+        tt {:foo t}
+        tt-hash (c/map->md5 tt) ;; {:foo {:foo 300, :toto 600}} 52a197cb51d65d93a047df1b7fa994aa)
+        mm-hash (c/map->md5 mm)] ;; {:foo {:foo 300, :toto 600}} d8a50edd5aeb65be51deb87eefc48f93
+    (is tt-hash mm-hash)
+    ))
+
+(deftest list-hash-test
+  (let [list-hash (c/map->md5 {:foo '(1)})
+        array-hash (c/map->md5 {:foo [1]})]
+    (is list-hash array-hash)))


### PR DESCRIPTION
- removing json serialization will use edn for computing the hash
- sorting the map will ensure predictable computations
- should fix #11