### PR TITLE
Remove broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,4 @@ Configurations can also be loaded from the `profiles.clj` file, where the dev co
    Re-evaluated code will be seen immediately in the service.
 
 ## Links
-* [Sequence design](https://decimals.substack.com/p/things-i-wish-i-knew-before-building)
 * [Open-source ledgers](http://decimals.app)

--- a/README.md
+++ b/README.md
@@ -73,4 +73,5 @@ Configurations can also be loaded from the `profiles.clj` file, where the dev co
    Re-evaluated code will be seen immediately in the service.
 
 ## Links
+* [Sequence design](https://web.archive.org/web/20210523054802/https://decimals.substack.com/p/things-i-wish-i-knew-before-building)
 * [Open-source ledgers](http://decimals.app)


### PR DESCRIPTION
The *Sequence Design* link at the bottom of the README currently points to a parked domain. This pull request removes the broken link.

# Changes Made:

Removed the *Sequence Design* link that pointed to a parked domain.

# References:

A loom video recording of the issue can be found [here](https://www.loom.com/share/bb98d3b16ba54f91940db6489bb16cd1?sid=283f6b14-2400-48a3-a19d-6dabd4e0e2e2)